### PR TITLE
Resolves #33

### DIFF
--- a/sonarqube_api/api.py
+++ b/sonarqube_api/api.py
@@ -98,13 +98,10 @@ class SonarAPIHandler(object):
         res = call(url, data=data or {})
 
         # Analyse response status and return or raise exception
+        # Note: redirects are followed automatically by requests
         if res.status_code < 300:
             # OK, return http response
             return res
-
-        elif res.status_code < 400:
-            # Redirect code, error
-            raise Exception("Don't know how to redirect to {}.".format(res.url))
 
         elif res.status_code == 400:
             # Validation error

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,13 +41,6 @@ class SonarAPIHandlerTest(TestCase):
         mock_get.return_value = resp
         self.assertRaises(StopIteration, next, self.h.get_metrics())
 
-        # Not authenticated, raises AuthError
-        e_msg = "Don't know how to redirect to http://correct.location.com:9000."
-        with self.assertRaisesRegexp(Exception, e_msg):
-            resp.status_code = 301
-            resp.url = 'http://correct.location.com:9000'
-            next(self.h.get_metrics())
-
         # Invalid data, raises ValidationError
         resp.status_code = 400
         resp.json.return_value = {'errors': [{'msg': 'invalid data for field'}]}


### PR DESCRIPTION
No need to handle this, since requests follows redirects by default for all methods except HEAD, so we'll never get a 3xx.
