### PR TITLE
Add support for token auth and subdirectories.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ return generators, so you still need to *get the next object*::
 
 Sonar authentication tokens can also be used in place of username and password,
 which is particularly useful when accessing the SonarQube API from a CI server,
-as tokens can easily be revoked in the event of unintended exposure.
+as tokens can easily be revoked in the event of unintended exposure::
 
     h = SonarAPIHandler(token='f052f55b127bb06f63c31cb2064ea301048d9e5d')
 

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,12 @@ return generators, so you still need to *get the next object*::
 
     proj = next(h.get_resources_full_data(resource='some:example'))
 
+Sonar authentication tokens can also be used in place of username and password,
+which is particularly useful when accessing the SonarQube API from a CI server,
+as tokens can easily be revoked in the event of unintended exposure.
+
+    h = SonarAPIHandler(token='f052f55b127bb06f63c31cb2064ea301048d9e5d')
+
 Supported Methods
 -----------------
 

--- a/sonarqube_api/api.py
+++ b/sonarqube_api/api.py
@@ -63,7 +63,7 @@ class SonarAPIHandler(object):
         # Prefer revocable authentication token over username/password if
         # both are provided
         if token:
-            self._session.auth = token, None
+            self._session.auth = token, ''
         elif user and password:
             self._session.auth = user, password
 

--- a/sonarqube_api/api.py
+++ b/sonarqube_api/api.py
@@ -16,7 +16,7 @@ class SonarAPIHandler(object):
     # Default host is local
     DEFAULT_HOST = 'http://localhost'
     DEFAULT_PORT = 9000
-    DEFAULT_SUBDIRECTORY = ''
+    DEFAULT_BASE_PATH = ''
 
     # Endpoint for resources and rules
     AUTH_VALIDATION_ENDPOINT = '/api/authentication/validate'
@@ -50,14 +50,14 @@ class SonarAPIHandler(object):
     )
 
     def __init__(self, host=None, port=None, user=None, password=None,
-                 subdirectory=None, token=None):
+                 base_path=None, token=None):
         """
         Set connection info and session, including auth (if user+password
         and/or auth token were provided).
         """
         self._host = host or self.DEFAULT_HOST
         self._port = port or self.DEFAULT_PORT
-        self._subdirectory = subdirectory or self.DEFAULT_SUBDIRECTORY
+        self._subdirectory = base_path or self.DEFAULT_BASE_PATH
         self._session = requests.Session()
 
         # Prefer revocable authentication token over username/password if

--- a/sonarqube_api/cmd/activate_rules.py
+++ b/sonarqube_api/cmd/activate_rules.py
@@ -29,6 +29,9 @@ parser.add_argument('--user', dest='user', type=str,
 parser.add_argument('--password', dest='password', type=str,
                     default=None,
                     help='Authentication password for source server')
+parser.add_argument('--authtoken', dest='authtoken', type=str,
+                    default=None,
+                    help='Authentication token for source server')
 
 
 def main():
@@ -36,8 +39,9 @@ def main():
     Activate rules in a profile using a SonarAPIHandler instance.
     """
     options = parser.parse_args()
-    h = SonarAPIHandler(options.host, options.port,
-                        options.user, options.password)
+    h = SonarAPIHandler(host=options.host, port=options.port,
+                        user=options.user, password=options.password,
+                        token=options.authtoken)
 
     # Counters (total, created, skipped and failed)
     a, f = 0, 0

--- a/sonarqube_api/cmd/activate_rules.py
+++ b/sonarqube_api/cmd/activate_rules.py
@@ -32,6 +32,9 @@ parser.add_argument('--password', dest='password', type=str,
 parser.add_argument('--authtoken', dest='authtoken', type=str,
                     default=None,
                     help='Authentication token for source server')
+parser.add_argument('--basepath', dest='basepath', type=str,
+                    default=None,
+                    help='The base-path of the Sonar installation. Defaults to "/"')
 
 
 def main():
@@ -41,7 +44,7 @@ def main():
     options = parser.parse_args()
     h = SonarAPIHandler(host=options.host, port=options.port,
                         user=options.user, password=options.password,
-                        token=options.authtoken)
+                        token=options.authtoken, base_path=options.basepath)
 
     # Counters (total, created, skipped and failed)
     a, f = 0, 0

--- a/sonarqube_api/cmd/export_rules.py
+++ b/sonarqube_api/cmd/export_rules.py
@@ -25,6 +25,9 @@ parser.add_argument('--user', dest='user', type=str,
 parser.add_argument('--password', dest='password', type=str,
                     default=None,
                     help='Authentication password')
+parser.add_argument('--authtoken', dest='authtoken', type=str,
+                    default=None,
+                    help='Authentication token')
 
 # Output directory argument
 parser.add_argument('--output-dir', dest='output', type=str,
@@ -55,7 +58,9 @@ def main():
     SonarAPIHandler connected to the given host.
     """
     options = parser.parse_args()
-    h = SonarAPIHandler(options.host, options.port, options.user, options.password)
+    h = SonarAPIHandler(host=options.host, port=options.port,
+                        user=options.user, password=options.password,
+                        token=options.authtoken)
 
     # Determine output csv and html file names
     csv_fn = os.path.expanduser(os.path.join(options.output, 'rules.csv'))

--- a/sonarqube_api/cmd/export_rules.py
+++ b/sonarqube_api/cmd/export_rules.py
@@ -28,6 +28,9 @@ parser.add_argument('--password', dest='password', type=str,
 parser.add_argument('--authtoken', dest='authtoken', type=str,
                     default=None,
                     help='Authentication token')
+parser.add_argument('--basepath', dest='basepath', type=str,
+                    default=None,
+                    help='The base-path of the Sonar installation. Defaults to "/"')
 
 # Output directory argument
 parser.add_argument('--output-dir', dest='output', type=str,
@@ -60,7 +63,7 @@ def main():
     options = parser.parse_args()
     h = SonarAPIHandler(host=options.host, port=options.port,
                         user=options.user, password=options.password,
-                        token=options.authtoken)
+                        token=options.authtoken, base_path=options.basepath)
 
     # Determine output csv and html file names
     csv_fn = os.path.expanduser(os.path.join(options.output, 'rules.csv'))

--- a/sonarqube_api/cmd/migrate_rules.py
+++ b/sonarqube_api/cmd/migrate_rules.py
@@ -26,6 +26,9 @@ parser.add_argument('--source-password', dest='source_password', type=str,
 parser.add_argument('--source-authtoken', dest='source_authtoken', type=str,
                     default=None,
                     help='Authentication token for source server')
+parser.add_argument('--sourcebasepath', dest='sourcebasepath', type=str,
+                    default=None,
+                    help='The base-path of the source Sonar installation. Defaults to "/"')
 
 # Target connection arguments
 parser.add_argument('--target-host', dest='target_host', type=str,
@@ -43,6 +46,9 @@ parser.add_argument('--target-password', dest='target_password', type=str,
 parser.add_argument('--target-authtoken', dest='target-authtoken', type=str,
                     default=None,
                     help='Authentication token for target server')
+parser.add_argument('--targetbasepath', dest='targetbasepath', type=str,
+                    default=None,
+                    help='The base-path of the target Sonar installation. Defaults to "/"')
 
 
 def main():
@@ -53,10 +59,10 @@ def main():
     options = parser.parse_args()
     sh = SonarAPIHandler(host=options.source_host, port=options.source_port,
                          user=options.source_user, password=options.source_password,
-                         token=options.source_authtoken)
+                         token=options.source_authtoken, base_path=options.sourcebasepath)
     th = SonarAPIHandler(host=options.target_host, port=options.target_port,
                          user=options.target_user, password=options.target_password,
-                         token=options.target_token)
+                         token=options.target_token, base_path=targetbasepath)
 
     # Get the generator of source rules
     rules = sh.get_rules(active_only=True, custom_only=True)

--- a/sonarqube_api/cmd/migrate_rules.py
+++ b/sonarqube_api/cmd/migrate_rules.py
@@ -23,6 +23,9 @@ parser.add_argument('--source-user', dest='source_user', type=str,
 parser.add_argument('--source-password', dest='source_password', type=str,
                     default=None,
                     help='Authentication password for source server')
+parser.add_argument('--source-authtoken', dest='source_authtoken', type=str,
+                    default=None,
+                    help='Authentication token for source server')
 
 # Target connection arguments
 parser.add_argument('--target-host', dest='target_host', type=str,
@@ -37,6 +40,9 @@ parser.add_argument('--target-user', dest='target_user', type=str,
 parser.add_argument('--target-password', dest='target_password', type=str,
                     default=None,
                     help='Authentication password for target server')
+parser.add_argument('--target-authtoken', dest='target-authtoken', type=str,
+                    default=None,
+                    help='Authentication token for target server')
 
 
 def main():
@@ -45,10 +51,12 @@ def main():
     SonarAPIHandler instances.
     """
     options = parser.parse_args()
-    sh = SonarAPIHandler(options.source_host, options.source_port,
-                         options.source_user, options.source_password)
-    th = SonarAPIHandler(options.target_host, options.target_port,
-                         options.target_user, options.target_password)
+    sh = SonarAPIHandler(host=options.source_host, port=options.source_port,
+                         user=options.source_user, password=options.source_password,
+                         token=options.source_authtoken)
+    th = SonarAPIHandler(host=options.target_host, port=options.target_port,
+                         user=options.target_user, password=options.target_password,
+                         token=options.target_token)
 
     # Get the generator of source rules
     rules = sh.get_rules(active_only=True, custom_only=True)

--- a/sonarqube_api/cmd/migrate_rules.py
+++ b/sonarqube_api/cmd/migrate_rules.py
@@ -62,7 +62,7 @@ def main():
                          token=options.source_authtoken, base_path=options.sourcebasepath)
     th = SonarAPIHandler(host=options.target_host, port=options.target_port,
                          user=options.target_user, password=options.target_password,
-                         token=options.target_token, base_path=targetbasepath)
+                         token=options.target_token, base_path=options.targetbasepath)
 
     # Get the generator of source rules
     rules = sh.get_rules(active_only=True, custom_only=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,7 @@ class SonarAPIHandlerTest(TestCase):
 
     def test_url_building(self):
         test = SonarAPIHandler(host='http://localhost', port=9001,
-                               subdirectory='/testing')
+                               base_path='/testing')
         self.assertEqual(
             "http://localhost:9001/testing{}".format(test.RESOURCES_ENDPOINT),
             test._get_url(test.RESOURCES_ENDPOINT))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,23 @@ class SonarAPIHandlerTest(TestCase):
     def setUp(self):
         self.h = SonarAPIHandler(user='admin', password='admin')
 
+    def test_url_building(self):
+        test = SonarAPIHandler(host='http://localhost', port=9001,
+                               subdirectory='/testing')
+        self.assertEqual(
+            "http://localhost:9001/testing{}".format(test.RESOURCES_ENDPOINT),
+            test._get_url(test.RESOURCES_ENDPOINT))
+
+        test = SonarAPIHandler(host='http://localhost', port=9001)
+        self.assertEqual(
+            "http://localhost:9001{}".format(test.RESOURCES_ENDPOINT),
+            test._get_url(test.RESOURCES_ENDPOINT))
+
+        test = SonarAPIHandler(host='http://localhost')
+        self.assertEqual(
+            "http://localhost:9000{}".format(test.RESOURCES_ENDPOINT),
+            test._get_url(test.RESOURCES_ENDPOINT))
+
     @mock.patch('sonarqube_api.api.requests.Session.get')
     def test_validate_auth(self, mock_res):
         resp = mock.MagicMock(status_code=200)

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -144,7 +144,7 @@ class ActivateRulesTest(TestCase):
         # Set call arguments
         parse_mock.return_value = mock.MagicMock(
             host='localhost', port='9000', user='pancho', password='primero',
-            profile_key='py-234345', filename='active-rules.csv'
+            profile_key='py-234345', filename='active-rules.csv', basepath=None
         )
 
         # Mock file handlers


### PR DESCRIPTION
Added two additional (optional) parameters to the SonarAPIHandler constructor:
- subdirectory: In the event that sonar is not hosted under a root directory (/), allows the specification of a subdirectory (e.g. '/sonar').
- token: Sonar authentication token. Can be provided in place of/addition to username and password.

Closes #46. Closes #47.
